### PR TITLE
remove currency

### DIFF
--- a/MakeOrderExample.py
+++ b/MakeOrderExample.py
@@ -82,7 +82,6 @@ if __name__ == "__main__":
         order_metadata["line_items"] = [new_line_item_uri]
         order_metadata["bureau"] = sesh.get_bureau_uri()
         order_metadata["name"] = "New Order for " + str(model_metadata["name"])
-        order_metadata["currency"] = "USD"
         order_metadata["shipping"] = quick_order_shipping_dict(
             sesh.get_any_shipping_uri()
         )


### PR DESCRIPTION
- remove currency
- currency is no longer an option for order level fields
- was causing an error `new order creation error {"errors": [{"code": "request-validation-error", "title": "You provided 'currency'. It is not a valid property for this resource"}]}`